### PR TITLE
WIP: Enable Instagram Fetcher

### DIFF
--- a/src/ConsoleApp/schema/instagram_3.3.json
+++ b/src/ConsoleApp/schema/instagram_3.3.json
@@ -1,0 +1,106 @@
+{
+    "name": "instagram",
+    "threads": 1,
+    "delay": 20,
+    "page_size": 20,
+    "columns":[
+        ["id", "bigint"]
+    ],
+    "edges": [{
+        "name": "media",
+        "time": [],
+        "columns": [
+            ["caption","text"],
+            ["children","json"],
+            ["comments_count","bigint"],
+            ["id","bigint"],
+            ["ig_id","bigint"],
+            ["like_count","bigint"],
+            ["media_type","text"],
+            ["media_url","text"],
+            ["permalink","text"],
+            ["shortcode","text"],
+            ["thumbnail_url","text"],
+            ["timestamp","timestamp without time zone"]
+        ],
+        "edges": [],
+        "instagram_insights": [{
+            "name": "insights",
+            "instagram_media_type": "video",
+            "columns": [],
+            "bounds": [],
+            "granularity": "lifetime",
+            "time": [],
+            "metrics": [
+                ["engagement", "bigint"],
+                ["impressions", "bigint"],
+                ["reach", "bigint"],
+                ["saved", "bigint"],
+                ["video_views", "bigint"]
+            ]
+        },{
+            "name": "insights",
+            "instagram_media_type": "image",
+            "columns": [],
+            "bounds": [],
+            "granularity": "lifetime",
+            "time": [],
+            "metrics": [
+                ["engagement", "bigint"],
+                ["impressions", "bigint"],
+                ["reach", "bigint"],
+                ["saved", "bigint"]
+            ]
+        },{
+            "name": "insights",
+            "instagram_media_type": "carousel_album",
+            "columns": [],
+            "bounds": [],
+            "granularity": "lifetime",
+            "time": [],
+            "metrics": [
+                ["carousel_album_engagement", "bigint"],
+                ["carousel_album_impressions", "bigint"],
+                ["carousel_album_reach", "bigint"],
+                ["carousel_album_saved", "bigint"]
+            ]
+        } ]
+    }],
+    "insights": [{
+            "name": "insights",
+            "granularity": "lifetime",
+            "columns": [
+                ["values", "json"],
+                ["name", "text"]
+            ],
+            "bounds": [],
+            "time": [],
+            "metrics": [
+                ["audience_city", "jsonb"],
+                ["audience_country", "jsonb"],
+                ["audience_gender_age", "jsonb"],
+                ["audience_locale", "jsonb"],
+                ["online_followers", "jsonb"]
+            ]
+        },{
+            "name": "insights",
+            "granularity": "day",
+            "columns": [
+                ["values", "json"],
+                ["name", "text"],
+                ["date_start", "timestamp without time zone"],
+                ["date_stop", "timestamp without time zone"]
+            ],
+            "time": [],
+            "bounds": [["creation_date"]],
+            "metrics": [
+                ["email_contacts", "bigint"],
+                ["follower_count", "bigint"],
+                ["get_directions_clicks", "bigint"],
+                ["phone_call_clicks", "bigint"],
+                ["profile_views", "bigint"],
+                ["text_message_clicks", "bigint"],
+                ["website_clicks", "bigint"]
+            ]
+        }]
+}

--- a/src/Jobs.Fetcher.Facebook/SchemaLoader.cs
+++ b/src/Jobs.Fetcher.Facebook/SchemaLoader.cs
@@ -23,7 +23,7 @@ namespace Jobs.Fetcher.Facebook {
             // Instagram.media problem is related to issue 182
 
             // return new List<string> { "page", "adaccount", "instagram" };
-            return new List<string> { "page", "adaccount" };
+            return new List<string> { "page", "adaccount", "instagram" };
         }
 
         public static T ParseCredentials<T>(string schema_name) {


### PR DESCRIPTION
<!--
  Thank you very much for contributing to the Jellyfish team by creating an issue! ❤️
  To avoid duplicate PR we ask you to check off the following list.
-->

<!-- Checked checkbox should look like this: [x] -->

- [x] I have searched the [PR](https://github.com/Marketing-Automation-Systems/jellyfish/pulls/) of this repository and believe that this is not a duplicate.

<!-- Short bullet list with the new changes proposed-->
**Describe the PR**
Fixes #26 

In this PR, we are enabling Instagram Fetcher. When this project was part of the FEE YEAR-AP, the Instagram Fetcher was failing due to a bug on the API and was disabled. Looks like the API solved the problem, so we can enable it again. 

**To Reproduce what was done**
Steps to reproduce the behavior:
1. Go to `src/ConsoleApp`
2. Run `dotnet run -- jobs -j Jobs.Fetcher.Facebook.instagram`
3. Wait Jobs finish seeing results