### PR TITLE
Enforce the Consistency on Database: Invalidate old Video Entries

### DIFF
--- a/Jobs.Fetcher.YouTube/Helpers/DbWriter.cs
+++ b/Jobs.Fetcher.YouTube/Helpers/DbWriter.cs
@@ -50,6 +50,7 @@ namespace Jobs.Fetcher.YouTube.Helpers {
                         case Modified.Updated:
                             logger.Debug("Found update to: {VideoId}", newObj.VideoId);
                             storedObj.ValidityEnd = newObj.ValidityStart;
+                            dlContext.Update(storedObj);
                             dlContext.Add(newObj);
                             break;
                         default:
@@ -78,6 +79,7 @@ namespace Jobs.Fetcher.YouTube.Helpers {
                         case Modified.Updated:
                             logger.Debug("Found update to: {VideoId} {CaptureDate}", newObj.VideoId, newObj.CaptureDate);
                             storedObj.ValidityEnd = newObj.ValidityStart;
+                            dlContext.Update(storedObj);
                             dlContext.Add(newObj);
                             break;
                         default:
@@ -106,6 +108,7 @@ namespace Jobs.Fetcher.YouTube.Helpers {
                         case Modified.Updated:
                             logger.Debug("Found update to: {PlaylistId}", newObj.PlaylistId);
                             storedObj.ValidityEnd = newObj.ValidityStart;
+                            dlContext.Update(storedObj);
                             dlContext.Add(newObj);
                             break;
                         default:
@@ -132,6 +135,7 @@ namespace Jobs.Fetcher.YouTube.Helpers {
                             break;
                         case Modified.Updated:
                             storedObj.ValidityEnd = newObj.ValidityStart;
+                            dlContext.Update(storedObj);
                             dlContext.Add(newObj);
                             break;
                         default:


### PR DESCRIPTION
We are getting some crashes due to multiple instances being selected:

 ```csharp
var storedObj = dlContext.Videos.SingleOrDefault(v => v.VideoId == newObj.VideoId && v.ValidityStart <= now && now < v.ValidityEnd);
```
In the example above, that filtering returns multiple instances, so `SingleOrDefault` raises an exception, and the fetcher crashes.

We change it to `LastOfDefault`.