### PR TITLE
Fix Youtube fetcher panicking if a user folder have no `youtube` subfolder or a credential inside it

### DIFF
--- a/Jobs.Fetcher.Facebook/SchemaLoader.cs
+++ b/Jobs.Fetcher.Facebook/SchemaLoader.cs
@@ -75,7 +75,6 @@ namespace Jobs.Fetcher.Facebook {
                 } else {
                     Console.WriteLine($"Missing or invalid {GetServiceName(schemaName)} credentials!");
                     Console.WriteLine($"Couldn't find any credential on folder '{credentialPath}'");
-                    Console.WriteLine($"File: {credentialFileName}\n");
                 }
             }
             return validSchemas;

--- a/Jobs.Fetcher.YouTube/YouTubeFetchers.cs
+++ b/Jobs.Fetcher.YouTube/YouTubeFetchers.cs
@@ -38,6 +38,12 @@ namespace Jobs.Fetcher.YouTube {
                         CredentialsDir = $"{usrDir}/youtube";
                         SecretsFile = $"{CredentialsDir}/client_secret.json";
 
+                        if (!Directory.Exists(CredentialsDir) || !File.Exists(SecretsFile)) {
+                            Console.WriteLine($"Missing or invalid Youtube credentials!");
+                            Console.WriteLine($"Couldn't find any credential on folder '{CredentialsDir}'");
+                            continue;
+                        }
+
                         jobs.AddRange(GetListOfJobs(youtubeServices));
                     }
                 }
@@ -49,7 +55,7 @@ namespace Jobs.Fetcher.YouTube {
                 if (e is DirectoryNotFoundException) {
                     message = String.Format("{0}\nCheck if the path above exists!", message);
                 }
-                System.Console.WriteLine(message);
+                Console.WriteLine(message);
                 return NoJobs;
             };
 


### PR DESCRIPTION
Add check before trying to open any directory or folder for Youtube fetcher