### PR TITLE
Updates the fetcher to get reactions and shares on v11.0

### DIFF
--- a/Andromeda.Commands/MigrateCommand.cs
+++ b/Andromeda.Commands/MigrateCommand.cs
@@ -7,7 +7,7 @@ namespace Andromeda.Commands {
 
     public static class MigrateCommand {
 
-        public static void Migrate(Databases db) {
+        public static void Migrate(Databases db, bool force_update = false) {
             switch (db) {
                 case Databases.LakeYouTubeData:
                     DatabaseOperations.Migrate<DataLakeYouTubeDataContext>();
@@ -22,7 +22,7 @@ namespace Andromeda.Commands {
                     DatabaseOperations.Migrate<DataLakeLoggingContext>();
                     break;
                 case Databases.LakeFacebook:
-                    Jobs.Fetcher.Facebook.DatabaseInitializer.Init();
+                    Jobs.Fetcher.Facebook.DatabaseInitializer.Init(force_update);
                     Jobs.Fetcher.Facebook.DatabaseInitializer.Init(new List<string> { "instagram" });
                     break;
                 default:
@@ -38,8 +38,8 @@ namespace Andromeda.Commands {
             Console.WriteLine("Successfully migrated data-lake.");
         }
 
-        public static void MigrateFacebook() {
-            Migrate(Databases.LakeFacebook);
+        public static void MigrateFacebook(bool force_update = false) {
+            Migrate(Databases.LakeFacebook, force_update);
             Console.WriteLine("Successfully migrated Facebook-lake.");
         }
     }

--- a/Andromeda.ConsoleApp/Program.cs
+++ b/Andromeda.ConsoleApp/Program.cs
@@ -82,14 +82,16 @@ namespace Andromeda.ConsoleApp {
                 var lake = command.Option("--data-lake", "Migrate data-lake databases", CommandOptionType.NoValue);
                 var facebook = command.Option("--facebook-lake", "Migrate facebook-lake database", CommandOptionType.NoValue);
 
+                var force_update = command.Option("-f|--force-update", "Checks and updates every column of every table.", CommandOptionType.NoValue);
+
                 command.OnExecute(() => {
                     if (lake.HasValue()) {
                         MigrateCommand.MigrateDataLake();
                     } else if (facebook.HasValue()) {
-                        MigrateCommand.MigrateFacebook();
+                        MigrateCommand.MigrateFacebook(force_update.HasValue());
                     } else {
                         MigrateCommand.MigrateDataLake();
-                        MigrateCommand.MigrateFacebook();
+                        MigrateCommand.MigrateFacebook(force_update.HasValue());
                     }
                     return 0;
                 });

--- a/Andromeda.ConsoleApp/schema/page_11.0.json
+++ b/Andromeda.ConsoleApp/schema/page_11.0.json
@@ -38,24 +38,6 @@
             "edges": [],
             "time": ["created_time"]
         }, {
-            "name": "reactions",
-            "ordering": "desc",
-            "columns": [
-                ["id", "bigint"],
-                ["name", "text"],
-                ["type", "text"]
-            ],
-            "time": []
-        }, {
-            "name": "sharedposts",
-            "ordering": "desc",
-            "columns": [
-                ["id", "text"],
-                ["story", "text"],
-                ["created_time", "timestamp without time zone"]
-            ],
-            "time": ["created_time"]
-        }, {
             "name": "crosspost_shared_pages",
             "ordering": "desc",
             "columns": [
@@ -82,9 +64,25 @@
                 ["total_video_impressions_paid", "bigint"],
                 ["total_video_retention_graph", "jsonb"],
                 ["total_video_view_time_by_age_bucket_and_gender", "jsonb"],
-                ["total_video_view_time_by_region_id", "jsonb"]
+                ["total_video_view_time_by_region_id", "jsonb"],
+                ["total_video_reactions_by_type_total", "jsonb"],
+                ["total_video_stories_by_action_type", "jsonb"]
             ],
             "time": []
+        },{
+            "name": "likes",
+            "granularity": "day",
+            "bounds": [
+                ["created_time"]
+            ],
+            "summary" : true,
+            "time": [],
+            "columns": [],
+            "metrics": [
+                ["total_count", "bigint"],
+                ["can_like", "bool"],
+                ["has_liked", "bool"]
+            ]
         }]
     }, {
         "name": "posts",

--- a/Jobs.Fetcher.Facebook/Client/Metadata/Insights.cs
+++ b/Jobs.Fetcher.Facebook/Client/Metadata/Insights.cs
@@ -9,7 +9,8 @@ namespace Jobs.Fetcher.Facebook {
             List<string> time,
             List<string[]> metrics,
             string granularity,
-            List<string[]> bounds
+            List<string[]> bounds,
+            bool? summary
             ): base(name, columns, null, null, time, null, null, "unordered") {
             // treat missing parameters
             if (bounds != null && bounds.Count() >= 1) {
@@ -19,6 +20,7 @@ namespace Jobs.Fetcher.Facebook {
                 }
             }
             Granularity = granularity ?? "lifetime";
+            Summary = summary ?? false;
             metrics = metrics ?? new List<string[]>();
             Metrics = metrics.Select(x => new Metrics(x)).ToDictionary(x => x.Name);
 
@@ -36,6 +38,7 @@ namespace Jobs.Fetcher.Facebook {
             }
         }
         public string Granularity { get; set; }
+        public bool Summary { get; set; }
         // If false: API returns data in the format: (date, metric, value), which is the format dealt by the code base.
         // If true: API returns data in the format: (metric, date, value), which must be transposed to (date, metric, value) before processing
         public bool Transposed { get => Metrics.Count() > 0; }
@@ -73,12 +76,13 @@ namespace Jobs.Fetcher.Facebook {
         public InstagramInsights(
             string name,
             string granularity,
+            bool? summary,
             List<string[]> bounds,
             List<string[]> columns,
             List<string[]> metrics,
             List<string> time,
             string instagram_media_type
-            ): base(name, columns, time, metrics, granularity, bounds) {
+            ): base(name, columns, time, metrics, granularity, bounds, summary) {
             InstagramMediaType = instagram_media_type ?? "";
         }
 

--- a/Jobs.Fetcher.Facebook/DatabaseInitializer.cs
+++ b/Jobs.Fetcher.Facebook/DatabaseInitializer.cs
@@ -5,59 +5,59 @@ namespace Jobs.Fetcher.Facebook {
 
     public static class DatabaseInitializer {
 
-        public static void Init() {
+        public static void Init(bool force_update = false) {
             foreach (var schemaName in SchemaLoader.SchemaList()) {
                 var schema = SchemaLoader.LoadSchema(schemaName);
-                Init(schema, null, null);
+                Init(schema, null, null, force_update);
             }
         }
 
         public static void Init(List<string> schemaList) {
             foreach (var schemaName in schemaList) {
                 var schema = SchemaLoader.LoadSchema(schemaName);
-                Init(schema, null, null);
+                Init(schema, null, null, false);
             }
         }
 
-        static void Init(Schema schema, string tableKey, string edge) {
+        static void Init(Schema schema, string tableKey, string edge, bool force_update) {
             DatabaseManager.CreateSchema();
             if (tableKey != null) {
-                InitTable(schema, tableKey, edge);
+                InitTable(schema, tableKey, edge, force_update);
             } else {
                 foreach (var v in schema.Edges.ToList()) {
-                    InitTable(schema, v.Key, null);
+                    InitTable(schema, v.Key, null, force_update);
                 }
-                InitInsights<Insights>(schema.Insights);
+                InitInsights<Insights>(schema.Insights, force_update);
             }
         }
 
-        static void InitTable(Schema schema, string tableKey, string edge) {
+        static void InitTable(Schema schema, string tableKey, string edge, bool force_update) {
             var table = schema.Edges[tableKey];
-            DatabaseManager.CreateTable(table);
+            DatabaseManager.CreateTable(table, force_update);
             if (edge != null) {
-                InitEdge(table, edge);
+                InitEdge(table, edge, force_update);
             } else {
                 foreach (var v in table.Edges.ToList()) {
-                    InitEdge(table, v.Key);
+                    InitEdge(table, v.Key, force_update);
                 }
-                InitEdge(table, "insights");
-                InitEdge(table, "instagram_insights");
+                InitEdge(table, "insights", force_update);
+                InitEdge(table, "instagram_insights", force_update);
             }
         }
 
-        static void InitEdge(Table table, string edge) {
+        static void InitEdge(Table table, string edge, bool force_update) {
             if (edge == "insights") {
-                InitInsights<Insights>(table.Insights);
+                InitInsights<Insights>(table.Insights, force_update);
             } else if (edge == "instagram_insights") {
-                InitInsights<InstagramInsights>(table.InstagramInsights);
+                InitInsights<InstagramInsights>(table.InstagramInsights, force_update);
             } else {
-                DatabaseManager.CreateTable(table.Edges[edge]);
+                DatabaseManager.CreateTable(table.Edges[edge], force_update);
             }
         }
 
-        static void InitInsights<T>(Dictionary<string, T> insights) where T : Insights  {
+        static void InitInsights<T>(Dictionary<string, T> insights, bool force_update) where T : Insights  {
             foreach (var i in insights.ToList()) {
-                DatabaseManager.CreateTable(i.Value);
+                DatabaseManager.CreateTable(i.Value, force_update);
             }
         }
     }


### PR DESCRIPTION
Facebook fetcher was not able to acquire reactions and shares on v11.0 because of deprecated endpoints

Changes the schema. fetcher and transformer in order for the new endpoints to be acquired and transformed.