### PR TITLE
Corrects summary fetching bug

### DIFF
--- a/Jobs.Fetcher.Facebook/Client/Fetcher.cs
+++ b/Jobs.Fetcher.Facebook/Client/Fetcher.cs
@@ -454,9 +454,11 @@ namespace Jobs.Fetcher.Facebook {
                 var row = FetchInsights(node["id"].ToString(), edge, range);
 
                 var result = new List<JObject>();
-                result.AddRange(((JArray) row.SelectToken("data")).ToObject<List<JObject>>());
+
                 if (edge.Summary) {
                     result.Add((JObject) row.SelectToken("summary"));
+                }else{
+                    result.AddRange(((JArray) row.SelectToken("data")).ToObject<List<JObject>>());
                 }
 
                 if (edge.Transposed && !edge.Summary) {
@@ -477,8 +479,8 @@ namespace Jobs.Fetcher.Facebook {
                         nobj.Add(edge.Source.Name + "_id", node["id"]);
                     }
                     if (edge.Summary) {
-                        nobj.Add("date_start", row["fetch_time"]);
-                        nobj.Add("date_stop", row["fetch_time"]);
+                        nobj.Add("date_start", row["fetch_time"].ToObject<DateTime>().ToString("yyyy-MM-dd 12:00:00"));
+                        nobj.Add("date_stop", row["fetch_time"].ToObject<DateTime>().AddDays(1.0).ToString("yyyy-MM-dd 12:00:00"));
                     }
 
                     string[] pk;


### PR DESCRIPTION
Hot-fix to add `date_start` and `date_end` to the Facebook fetcher in the context of the new endpoints (`reactions`, `sharedposts`, and `likes`).