### PR TITLE
Corrections to YouTube Studio fetcher tests

### DIFF
--- a/Jobs.Fetcher.YouTubeStudio/Helpers/DbWriter.cs
+++ b/Jobs.Fetcher.YouTubeStudio/Helpers/DbWriter.cs
@@ -32,12 +32,12 @@ namespace Jobs.Fetcher.YouTubeStudio.Helpers {
         {
             var validityStart = DateTime.UtcNow;
             var validityEnd = DateTime.MaxValue;
-            var EventDate = EpochToDateTime(dto.EventDate);
+            var eventTime = EpochToDateTime(dto.EventDate);
 
             return new Video {
                 ValidityStart = validityStart,
                 ValidityEnd = validityEnd,
-                EventDate = EventDate,
+                EventDate = eventTime.ToUniversalTime().Date,
                 ChannelId = dto.ChannelId,
                 VideoId = dto.VideoId,
                 Metric = dto.Metric,

--- a/Jobs.Fetcher.YouTubeStudio/YouTubeStudioFetcherJob.cs
+++ b/Jobs.Fetcher.YouTubeStudio/YouTubeStudioFetcherJob.cs
@@ -40,7 +40,7 @@ namespace Jobs.Fetcher.YouTubeStudio {
                 return;
             }
             Logger.Information($"Decoded {videos.Count} videos.");
-            DbWriter.Write(videos, Logger);
+            DbWriter.WriteDTOs(videos, Logger);
         }
     }
 }

--- a/Test/YouTubeStudioFetcherTest.cs
+++ b/Test/YouTubeStudioFetcherTest.cs
@@ -224,7 +224,7 @@ namespace Test.YouTubeStudio {
             return v =>
                 v.VideoId == videoDTO.VideoId
                 && v.ChannelId == videoDTO.ChannelId
-                && v.EventDate == DbWriter.EpochToDateTime(videoDTO.EventDate)
+                && v.EventDate == DbWriter.EpochToDateTime(videoDTO.EventDate).ToUniversalTime().Date
                 && v.Metric == videoDTO.Metric
                 && v.Value == videoDTO.Value;
         }

--- a/Test/YouTubeStudioFetcherTest.cs
+++ b/Test/YouTubeStudioFetcherTest.cs
@@ -62,7 +62,7 @@ namespace Test.YouTubeStudio {
                 {
                     ""videoId"": ""a38f0c8e8a66c85b5a13e9e5a6fe6a56"",
                     ""channelId"": ""3ac57fb4e69e34d0"",
-                    ""dateMeasure"": 1407734809,
+                    ""eventDate"": 1407734809,
                     ""metric"": ""Impressions"",
                     ""value"": 6811
                 }
@@ -70,7 +70,7 @@ namespace Test.YouTubeStudio {
             var expected = new Video_DTO{
                 VideoId = "a38f0c8e8a66c85b5a13e9e5a6fe6a56",
                 ChannelId = "3ac57fb4e69e34d0",
-                DateMeasure = 1407734809,
+                EventDate = 1407734809,
                 Metric = "Impressions",
                 Value = 6811
             };
@@ -90,14 +90,14 @@ namespace Test.YouTubeStudio {
                 {
                     ""videoId"": ""a38f0c8e8a66c85b5a13e9e5a6fe6a56"",
                     ""channelId"": ""3ac57fb4e69e34d0"",
-                    ""dateMeasure"": 1371063987,
+                    ""eventDate"": 1371063987,
                     ""metric"": ""Impressions"",
                     ""value"": 3201
                 },
                 {
                     ""videoId"": ""a38f0c8e8a66c85b5a13e9e5a6fe6a56"",
                     ""channelId"": ""3ac57fb4e69e34d0"",
-                    ""dateMeasure"": 1548401269,
+                    ""eventDate"": 1548401269,
                     ""metric"": ""Shares"",
                     ""value"": 9764
                 }
@@ -105,14 +105,14 @@ namespace Test.YouTubeStudio {
             var expected_01 = new Video_DTO{
                 VideoId = "a38f0c8e8a66c85b5a13e9e5a6fe6a56",
                 ChannelId = "3ac57fb4e69e34d0",
-                DateMeasure = 1371063987,
+                EventDate = 1371063987,
                 Metric = "Impressions",
                 Value = 3201
             };
             var expected_02 = new Video_DTO{
                 VideoId = "a38f0c8e8a66c85b5a13e9e5a6fe6a56",
                 ChannelId = "3ac57fb4e69e34d0",
-                DateMeasure = 1548401269,
+                EventDate = 1548401269,
                 Metric = "Shares",
                 Value = 9764
             };
@@ -224,7 +224,7 @@ namespace Test.YouTubeStudio {
             return v =>
                 v.VideoId == videoDTO.VideoId
                 && v.ChannelId == videoDTO.ChannelId
-                && v.DateMeasure == DbWriter.EpochToDateTime(videoDTO.DateMeasure)
+                && v.EventDate == DbWriter.EpochToDateTime(videoDTO.EventDate)
                 && v.Metric == videoDTO.Metric
                 && v.Value == videoDTO.Value;
         }
@@ -247,14 +247,14 @@ namespace Test.YouTubeStudio {
             var video_dto_01 = new Video_DTO {
                 VideoId = "a38f0c8e8a66c85b5a13e9e5a6fe6a56",
                 ChannelId = "3ac57fb4e69e34d0",
-                DateMeasure = 1371063987,
+                EventDate = 1371063987,
                 Metric = "Impressions",
                 Value = 3201
             };
             var video_dto_02 = new Video_DTO {
                 VideoId = "a38f0c8e8a66c85b5a13e9e5a6fe6a56",
                 ChannelId = "3ac57fb4e69e34d0",
-                DateMeasure = 1371063987,
+                EventDate = 1371063987,
                 Metric = "Views",
                 Value = 5
             };
@@ -295,14 +295,14 @@ namespace Test.YouTubeStudio {
             var video_dto_01 = new Video_DTO {
                 VideoId = "a38f0c8e8a66c85b5a13e9e5a6fe6a56",
                 ChannelId = "3ac57fb4e69e34d0",
-                DateMeasure = 1639969200, /* 2021-20-12 */
+                EventDate = 1639969200, /* 2021-20-12 */
                 Metric = "Impressions",
                 Value = 1234
             };
             var video_dto_02 = new Video_DTO {
                 VideoId = "a38f0c8e8a66c85b5a13e9e5a6fe6a56",
                 ChannelId = "3ac57fb4e69e34d0",
-                DateMeasure = 1640401200, /* 2021-25-12 */
+                EventDate = 1640401200, /* 2021-25-12 */
                 Metric = "Impressions",
                 Value = 5678
             };
@@ -345,14 +345,14 @@ namespace Test.YouTubeStudio {
             var video_dto_01 = new Video_DTO {
                 VideoId = "a38f0c8e8a66c85b5a13e9e5a6fe6a56",
                 ChannelId = "3ac57fb4e69e34d0",
-                DateMeasure = 1639969250,
+                EventDate = 1639969250,
                 Metric = "Impressions",
                 Value = 1234
             };
             var video_dto_02 = new Video_DTO {
                 VideoId = "a38f0c8e8a66c85b5a13e9e5a6fe6a56",
                 ChannelId = "3ac57fb4e69e34d0",
-                DateMeasure = 1639969251,
+                EventDate = 1639969251,
                 Metric = "Impressions",
                 Value = 5678
             };
@@ -393,22 +393,22 @@ namespace Test.YouTubeStudio {
         [Trait("Category","YouTubeStudio")]
         public void SameVideo_SameMetric_DiffDates_02_Test()
         {
-            /* In case we insert first the one with the later DateMeasure,
+            /* In case we insert first the one with the later EventDate,
             does it make any difference? It shouldn't, the matter here is
-            order of insertion, not which one has the higher DateMeasure */
+            order of insertion, not which one has the higher EventDate */
             Logger.Information("Inserting same video with same metric, "
                 + "same date, different values...");
             var video_dto_01 = new Video_DTO {
                 VideoId = "a38f0c8e8a66c85b5a13e9e5a6fe6a56",
                 ChannelId = "3ac57fb4e69e34d0",
-                DateMeasure = 1639969251,
+                EventDate = 1639969251,
                 Metric = "Impressions",
                 Value = 1234
             };
             var video_dto_02 = new Video_DTO {
                 VideoId = "a38f0c8e8a66c85b5a13e9e5a6fe6a56",
                 ChannelId = "3ac57fb4e69e34d0",
-                DateMeasure = 1639969250,
+                EventDate = 1639969250,
                 Metric = "Impressions",
                 Value = 5678
             };

--- a/Test/YouTubeStudioFetcherTest.cs
+++ b/Test/YouTubeStudioFetcherTest.cs
@@ -263,7 +263,7 @@ namespace Test.YouTubeStudio {
                 DeleteAllVideos(context);
                 var now = DateTime.UtcNow;
                 var video_DTOs = new List<Video_DTO>{video_dto_01, video_dto_02};
-                DbWriter.Write(video_DTOs, Logger);
+                DbWriter.WriteDTOs(video_DTOs, Logger);
 
                 var videos = context.Videos;
                 var videosList = videos.ToList();
@@ -311,7 +311,7 @@ namespace Test.YouTubeStudio {
                 DeleteAllVideos(context);
                 var now = DateTime.UtcNow;
                 var video_DTOs = new List<Video_DTO>{video_dto_01, video_dto_02};
-                DbWriter.Write(video_DTOs, Logger);
+                DbWriter.WriteDTOs(video_DTOs, Logger);
 
                 var videos = context.Videos;
                 var videosList = videos.ToList();
@@ -361,7 +361,7 @@ namespace Test.YouTubeStudio {
                 DeleteAllVideos(context);
                 var now = DateTime.UtcNow;
                 var video_DTOs = new List<Video_DTO>{video_dto_01, video_dto_02};
-                DbWriter.Write(video_DTOs, Logger);
+                DbWriter.WriteDTOs(video_DTOs, Logger);
 
                 var videos = context.Videos;
                 var videosList = videos.ToList();
@@ -417,7 +417,7 @@ namespace Test.YouTubeStudio {
                 DeleteAllVideos(context);
                 var now = DateTime.UtcNow;
                 var video_DTOs = new List<Video_DTO>{video_dto_01, video_dto_02};
-                DbWriter.Write(video_DTOs, Logger);
+                DbWriter.WriteDTOs(video_DTOs, Logger);
 
                 var videos = context.Videos;
                 var videosList = videos.ToList();


### PR DESCRIPTION
While running the tests for Year Ap, I noticed some problems running the fetcher. This was due to:
- Variable name was changed in the entire project, but not for the YTS fetcher tests (I wrote the tests before the rename, and forgot to add the rename to the PR I had already opened)
- We are handling all dates as Universal Time, and that had not been considered in these tests

Last but not least:
- A slightly different interface was implemented for storing the objects read from the JSON files into the database. The reason for that was separation of components on a per-function basis, and allowing a better interface for testing.