### PR TITLE
Catches exeption when dict already has the value being added

### DIFF
--- a/Andromeda.Commands/RunJobsCommand.cs
+++ b/Andromeda.Commands/RunJobsCommand.cs
@@ -26,7 +26,12 @@ namespace Andromeda.Commands {
         public static Dictionary<string, AbstractJob> BuildJobsDict(IEnumerable<AbstractJob> jobList) {
             var jobDict = new Dictionary<string, AbstractJob>();
             foreach (var job in jobList) {
-                jobDict.Add(job.Id(), job);
+                try{
+                    jobDict.Add(job.Id(), job);
+                }
+                catch (ArgumentException) {
+                    Console.WriteLine($"Job {job.Id()} already added.");
+                }
             }
             return jobDict;
         }


### PR DESCRIPTION
Job lists are being created for each user folder on the credentials directory, causing errors when repeated jobs are added to the Job Dictionary. This catches this exception.