### PR TITLE
(YT Viewer Percentages) Fixes null task crashing job

### DIFF
--- a/Jobs.Fetcher.YouTube/Helpers/ApiDataFetcher.cs
+++ b/Jobs.Fetcher.YouTube/Helpers/ApiDataFetcher.cs
@@ -613,6 +613,11 @@ namespace Jobs.Fetcher.YouTube.Helpers {
         }
 
         public void DoViewerPercentageTask(ViewerPercentagesTask task) {
+            if (task == null || task.VideoId == null || task.EndDate == null) {
+                _logger.Error("DoViewerPercentageTask: received a null task! Skipping");
+                return;
+            }
+
             var viewerPercentages = RunViewerPercentageReport(task);
 
             if (viewerPercentages.Any()) {


### PR DESCRIPTION
I have research and don't know yet what the ultimate cause of this bug is, but hopefully this will avoid it crashing the job when it happens